### PR TITLE
add config option for httpRealm and note that it must match viewer

### DIFF
--- a/_wiki/cont3xt.md
+++ b/_wiki/cont3xt.md
@@ -136,6 +136,7 @@ webBasePath | / | The base url for Cont3xt web requests. Must end with a / or ba
 certFile | empty | Public certificate to use for https, if not set then http will be used. keyFile must also be set.
 keyFile | empty | Private certificate to use for https, if not set then http will be used. certFile must also be set.
 userNameHeader | anonymous | Header to use for determining the username to check in the database for instead of using http digest. Set to <strong>digest</strong> to use http digest authentication.
+httpRealm | Moloch | The Realm to use with digest authentication. Must match the setting from the Viewer as set in `config.ini`.
 userAgent | cont3xt | The http user-agent header to use when talking to remote services
 geoLite2ASN | | <a href="settings#geolite2asn">settings page</a>
 geoLite2Country | | <a href="settings#geolite2country">settings page</a>


### PR DESCRIPTION
Add line to indicate `httpRealm` setting and that it must match what Viewer uses as set in `config.pl`.

I confirm that this contribution is made under an Apache 2.0 license and that I have the authority necessary to make this contribution on behalf of its copyright owner.