### PR TITLE
Add missing option/value to authMode doc

### DIFF
--- a/_data/shared/security.yml
+++ b/_data/shared/security.yml
@@ -43,6 +43,7 @@ settings:
         <li>"basic+form" - Use basic auth when present otherwise use form auth. This is useful when you want to support API calls using basic auth.</li>
         <li>"digest" or EMPTY - Use digest auth where browser based digest authentication is used.</li>
         <li>"form" - Use a html form to enter the user/password.</li>
+        <li>"header" - Use with <a href="#userNameHeader">userNameHeader</a>.</li>
         <li>"oidc" -  Use OIDC authentication.</li>
         <li>"anonymous" - Use anonymous authentication.</li>
         <li>"s2s" -  Only server to server authentication is allowed</li>

--- a/_data/shared/security.yml
+++ b/_data/shared/security.yml
@@ -43,7 +43,7 @@ settings:
         <li>"basic+form" - Use basic auth when present otherwise use form auth. This is useful when you want to support API calls using basic auth.</li>
         <li>"digest" or EMPTY - Use digest auth where browser based digest authentication is used.</li>
         <li>"form" - Use a html form to enter the user/password.</li>
-        <li>"header" - Use with <a href="#userNameHeader">userNameHeader</a>.</li>
+        <li>"header" - Use a http header containing the user id for authentication, see <a href="#userNameHeader">userNameHeader</a>.</li>
         <li>"oidc" -  Use OIDC authentication.</li>
         <li>"anonymous" - Use anonymous authentication.</li>
         <li>"s2s" -  Only server to server authentication is allowed</li>


### PR DESCRIPTION
*Not* setting `authMode=header` when using `userNameHeader` will generate the following error on Arkime 5.2.0:

```
WARNING - Using authMode=header since not set, add to config file to silence this warning.
```

This PR adds the option to the documentation as well.