### PR TITLE
docs: warn about OpenSearch 2.19.0 zstd compression bug

### DIFF
--- a/_wiki/install.md
+++ b/_wiki/install.md
@@ -48,6 +48,8 @@ The official matrix of supported versions of OpenSearch and Elasticsearch is ava
 ### Download and Install OpenSearch or Elasticsearch
 {: .subsection }
 
+**Note:** Avoid OpenSearch 2.19.0 — it has a [known bug](https://github.com/opensearch-project/OpenSearch/issues/17339) that causes HTTP responses to hang when the client supports zstd compression (curl 8.5.0+, the default on Debian 13 and Ubuntu 24.04). Use OpenSearch 2.18.0 or 3.x instead, or set `http.compression: false` in `opensearch.yml` as a workaround. See the [FAQ](https://arkime.com/faq#http-compression) for details.
+
 There are many ways to download and install [OpenSearch](https://opensearch.org/downloads.html) or [Elasticsearch](https://www.elastic.co/downloads/elasticsearch), we recommend using the official packages for your Linux distribution when possible.
 For a test environment, running OpenSearch or Elasticsearch on the same machine as the Arkime sensor will work, otherwise, please use separate machines.
 In a production environment, we recommend having at least three machines for OpenSearch/Elasticsearch to provide redundancy, and they work best with three leader/master nodes.

--- a/faq.html
+++ b/faq.html
@@ -526,7 +526,7 @@ title: FAQ
               5.2.0+
             </td>
             <td>
-              1.x, 2.x, 3.x (2.10+ or 3.x recommended), 2.19.0 broken, 3.x requires Arkime 5.7.0+
+              1.x, 2.x, 3.x (2.10+ or 3.x recommended), <a href="#http-compression">2.19.0 broken</a>, 3.x requires Arkime 5.7.0+
             </td>
             <td>
               7.10+, 8.x, 9.x (8.10+ or 9.x recommended)
@@ -552,7 +552,7 @@ title: FAQ
               4.3.2+ (4.6.0 recommended)
             </td>
             <td>
-              1.x, 2.x, 3.x (2.10+ or 3.x recommended), 2.19.0 broken, 3.x requires Arkime 5.7.0+
+              1.x, 2.x, 3.x (2.10+ or 3.x recommended), <a href="#http-compression">2.19.0 broken</a>, 3.x requires Arkime 5.7.0+
             </td>
             <td>
               7.10+, 8+, 9.x (7.17+, 8.10+ recommended), 9.x requires Arkime 5.7.0+
@@ -574,7 +574,7 @@ title: FAQ
               3.3.0+ (3.4.0+ recommended)
             </td>
             <td>
-              1.x, 2.x (2.3+ recommended), 2.19.0 broken
+              1.x, 2.x (2.3+ recommended), <a href="#http-compression">2.19.0 broken</a>
             </td>
             <td>
               7.10+, 8+
@@ -596,7 +596,7 @@ title: FAQ
               2.4.0
             </td>
             <td>
-              1.x, 2.x (2.3+ recommended), 2.19.0 broken
+              1.x, 2.x (2.3+ recommended), <a href="#http-compression">2.19.0 broken</a>
             </td>
             <td>
               7.10+, not 8.x
@@ -1999,6 +1999,17 @@ cluster.routing.allocation.disk.watermark.flood_stage: 100gb</code></pre>
           </a>
         </p>
         <pre><code>http.compression: true</code></pre>
+        <div class="alert alert-warning">
+          <b>Warning:</b> OpenSearch 2.19.0 has a
+          <a href="https://github.com/opensearch-project/OpenSearch/issues/17339" rel="nofollow">known bug</a>
+          where HTTP responses hang when the client sends <code>Accept-Encoding: zstd</code>.
+          Since Arkime's <code>.deb</code> packages link against system libcurl, and curl 8.5.0+
+          (the default on Debian 13 and Ubuntu 24.04) sends <code>Accept-Encoding: zstd</code>
+          automatically, Arkime capture will hang when talking to OpenSearch 2.19.0 with
+          compression enabled. This was fixed in OpenSearch 3.x but never backported to 2.x.
+          <b>Workarounds:</b> set <code>http.compression: false</code> in
+          <code>opensearch.yml</code>, or upgrade to OpenSearch 3.x.
+        </div>
 
         <h4 id="recovery-time">
           Recovery Time


### PR DESCRIPTION
## Summary

- Add warning to the FAQ HTTP Compression section explaining that OpenSearch 2.19.0 has a [known bug](https://github.com/opensearch-project/OpenSearch/issues/17339) where HTTP responses hang when the client sends `Accept-Encoding: zstd` (curl 8.5.0+, the default on Debian 13 and Ubuntu 24.04)
- Link the existing "2.19.0 broken" entries in the compatibility table to the HTTP Compression section so users can find the explanation and workarounds
- Add a note to the install guide warning users away from OpenSearch 2.19.0

**Workarounds:** `http.compression: false` in `opensearch.yml`, or upgrade to OpenSearch 3.x.

**Context:** Investigated in arkime/arkime#3817. The fix was merged to OpenSearch `main` (3.x) via [opensearch-project/OpenSearch#17408](https://github.com/opensearch-project/OpenSearch/pull/17408) but never backported to 2.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)