### PR TITLE
Add iCloud Private Relay configuration

### DIFF
--- a/_posts/wiseconfigs/2021-03-15-azure.md
+++ b/_posts/wiseconfigs/2021-03-15-azure.md
@@ -1,6 +1,6 @@
 ---
 title: Azure IPs
-description: 'Download the Azure IP CIDRs from Amazon and add cloud.region and cloud.service fields to the sessions that match.'
+description: 'Download the Azure IP CIDRs from Microsoft and add cloud.region and cloud.service fields to the sessions that match.'
 tags: azure ip cloud
 ---
 

--- a/_posts/wiseconfigs/2021-03-15-gcloud-ips.md
+++ b/_posts/wiseconfigs/2021-03-15-gcloud-ips.md
@@ -1,6 +1,6 @@
 ---
 title: Google Cloud IPs4
-description: 'Download the GCloud IP CIDRs from Amazon and add cloud.region and cloud.service fields to the sessions that match.'
+description: 'Download the GCloud IP CIDRs from Google and add cloud.region and cloud.service fields to the sessions that match.'
 tags: google cloud gcloud ip
 ---
 

--- a/_posts/wiseconfigs/2026-06-06-icloud-private-relay-ips.md
+++ b/_posts/wiseconfigs/2026-06-06-icloud-private-relay-ips.md
@@ -1,0 +1,19 @@
+---
+title: iCloud Private Relay IPs
+description: "Download the iCloud Private Relay egress IP CIDRs from Apple and add mask.country, mask.region and mask.city fields to the sessions that match, providing geolocation of masked Apple devices."
+tags: apple icloud ip cloud vpn proxy relay
+---
+
+```
+{
+  "url:icloud-private-relay-ips": {
+    "type": "ip",
+    "format": "csv",
+    "column": "0",
+    "url": "https://mask-api.icloud.com/egress-ip-ranges.csv",
+    "reload": "120",
+    "fields": "field:mask.country;db:mask.country;kind:termfield;friendly:Country;shortcut:1\\nfield:mask.region;db:mask.region;kind:termfield;friendly:Region;shortcut:2\\nfield:mask.city;db:mask.city;kind:termfield;friendly:City;shortcut:3",
+    "view": "require:mask;title:Apple Private Relay;section:mask;fields:mask.country,mask.region,mask.city"
+  }
+}
+```


### PR DESCRIPTION
Add the iCloud Private Relay wise configuration. Apple leverages third-party providers, [such as Cloudflare](https://blog.cloudflare.com/icloud-private-relay/), to achieve egress connections; This wise configuration enriches IPs using [Apple's geolocation feed](https://developer.apple.com/icloud/prepare-your-network-for-icloud-private-relay/), providing approximate indications on a masked device's equivalent geolocation.